### PR TITLE
Added basic usage handshake function

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $optionsOrUri = [
   'host' => 'localhost',
   'port' => '443',
   'path' => '/socketcluster/',
-  'origin' => 'https://example.com'
+  'origin' => 'https://example.com',
   'query' => [
     'servicekey' => 'abc'
   ],

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ $optionsOrUri = [
 $websocket = \SocketCluster\WebSocket::factory($optionsOrUri);
 $socket = new \SocketCluster\SocketCluster($websocket);
 
+// Perform Handshake
+$socket->handshake('OPTIONAL_TOKEN');
+
 // Event Emit
 $data = ['message' => 'FooBar'];
 $socket->publish('CHANNEL_NAME', $data);

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ $optionsOrUri = [
   'host' => 'localhost',
   'port' => '443',
   'path' => '/socketcluster/',
+  'origin' => 'https://example.com'
   'query' => [
     'servicekey' => 'abc'
   ],

--- a/src/SocketCluster.php
+++ b/src/SocketCluster.php
@@ -26,6 +26,23 @@ class SocketCluster
     {
         $this->websocket = $websocket;
     }
+    
+    /**
+     * Handshake
+     *
+     * @param string|null  $token
+     * @param Closure|null $callback
+     *
+     * @return boolean
+     */
+    public function handshake($token = null, Closure $callback = null)
+    {
+        $pubData = [
+            'authToken' => $token,
+        ];
+        
+        return $this->emit('#handshake', $pubData, $callback);
+    }
 
     /**
      * Publish Channel

--- a/src/WebSocket.php
+++ b/src/WebSocket.php
@@ -14,7 +14,7 @@ class WebSocket
     {
         $socket_uri = self::parseOptions($options);
 
-        return new Client($socket_uri);
+        return new Client($socket_uri, (isset($options['origin'])) ? array('headers' => array('origin' => trim($options['origin'], '/'))) : array());
     }
 
     /**


### PR DESCRIPTION
I've updated the basic usage so the Socket server can perform a handshake first, before publishing messages from the client-side.
Function is basically the same as SocketCluster uses in their (Version 16) client-js file.

I've tested this on one of my own projects, as I could not perform a connection with the Socket server at first.

I've not tested Laravel and Pimple, as I'm not familiar with those frameworks.